### PR TITLE
Added public teacher donation page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,8 @@ import SignupPage from './pages/SignupPage';
 // Dashboard Pages
 import DashboardLayout from './components/TeacherDashboard/DashboardLayout';
 import TeacherDashboardPage from './pages/Dashboard/TeacherDashboardPage';
+import DonationLayout from './components/TeacherDonation/DonationLayout'
+import TeacherDonationPage from './pages/TeacherDonationPage'
 import Settings from './pages/Dashboard/Settings';
 
 function App() {
@@ -37,10 +39,10 @@ function App() {
                         <Route path='settings' element={<Settings />} />
                     </Route>
                     {/* Public Donation */}
-                    {/* <Route path='/donation exect element={}>
-                        {/* <Route path='/teacher/:teacherId' element={} /> */}
+                    <Route path='/donations' exact element={<DonationLayout />}>
+                        <Route index element={<TeacherDonationPage />} />
                     {/* /donation/teacher/:teacherId/ */}
-                    {/* </Route> */}
+                    </Route>
                 </Routes>
             </Router>
         </div>

--- a/src/components/TeacherDashboard/DashboardLayout.js
+++ b/src/components/TeacherDashboard/DashboardLayout.js
@@ -63,6 +63,15 @@ function DashboardLayout() {
                             <Icon name='log out' />
                             Log Out
                         </Menu.Item>
+                        <Menu.Item
+                            link
+                            as={Link}
+                            to='/'
+                            name='settings'
+                        >
+                            <Icon name='home' />
+                            Home Page
+                        </Menu.Item>
                     </Menu.Menu>
                 </Menu>
             </div>

--- a/src/components/TeacherDonation/DonationLayout.js
+++ b/src/components/TeacherDonation/DonationLayout.js
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Image, Menu, Icon } from 'semantic-ui-react';
+import { Navigate, Link, Outlet } from 'react-router-dom';
+
+
+function DonationLayout() {
+
+    const [teacher, setTeacher] = useState('John Doe');
+
+    return (
+        <div className='container'>
+            <div className='sidebar'>
+                <Menu icon='labeled' fluid borderless inverted vertical>
+                    <Menu.Item>
+                        <Image
+                            centered
+                            alt='logo'
+                            src='../logo.png'
+                            size='small'
+                        />
+                    </Menu.Item>
+                    <Menu.Item link as={Link} to='/donations' name='main'>
+                        {teacher}'s Classroom Page
+                    </Menu.Item>
+                    <Menu.Menu>
+                        <Menu.Item
+                            link
+                            as={Link}
+                            to='/'
+                            name='settings'
+                        >
+                            <Icon name='home' />
+                            Home Page
+                        </Menu.Item>
+                    </Menu.Menu>
+                </Menu>
+            </div>
+            <div className='dashboard'>
+                <Outlet />
+            </div>
+        </div>
+    );
+}
+
+export default DonationLayout;

--- a/src/components/TeacherDonation/SupplyRowSimple.js
+++ b/src/components/TeacherDonation/SupplyRowSimple.js
@@ -1,0 +1,17 @@
+import React, { useState } from 'react';
+import { Table } from 'semantic-ui-react';
+
+function SupplyRowSimple({ supply }) {
+    const [supplyName, setSupplyName] = useState(supply.item);
+    const [qtyNeeded, setQtyNeeded] = useState(supply.totalQtyNeeded);
+    return (
+        <>
+            <Table.Row>
+                <Table.Cell>{supply.item}</Table.Cell>
+                <Table.Cell>{supply.totalQtyNeeded}</Table.Cell>
+                <Table.Cell>{supply.qtyDonated}</Table.Cell>
+            </Table.Row>
+        </>
+    );
+}
+export default SupplyRowSimple;

--- a/src/components/TeacherDonation/SupplyTableSimple.js
+++ b/src/components/TeacherDonation/SupplyTableSimple.js
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { Table } from 'semantic-ui-react';
+import SupplyRowSimple from './SupplyRowSimple';
+
+function SupplyTableSimple({
+    supplies
+}) {
+    const [itemName, setItemName] = useState('');
+    const [totalNeeded, setTotalNeeded] = useState(0);
+
+    return (
+        <Table basic="very" celled selectable>
+            <Table.Header >
+                <Table.Row>
+                    <Table.HeaderCell>Item</Table.HeaderCell>
+                    <Table.HeaderCell>Quantity Needed</Table.HeaderCell>
+                    <Table.HeaderCell>Quantity Donated</Table.HeaderCell>
+                    
+                </Table.Row>
+            </Table.Header>
+            <Table.Body>
+                {supplies.map((supply, i) => (
+                    <SupplyRowSimple
+                        key={i}
+                        supply={supply}
+                    />
+                ))}
+            </Table.Body>
+        </Table>
+    );
+}
+
+export default SupplyTableSimple;

--- a/src/pages/TeacherDonationPage.js
+++ b/src/pages/TeacherDonationPage.js
@@ -1,0 +1,79 @@
+import React, { useState, useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import SupplyTableSimple from '../components/TeacherDonation/SupplyTableSimple.js';
+//import MetricsCards from '../components/TeacherDashboard/MetricsCards';
+import { Header, Button, Container, Message, Divider } from 'semantic-ui-react';
+//import AuthService from '../services/auth.service';
+
+function TeacherDonationPage() {
+    const [teacher, setTeacher] = useState('John Doe')
+    const [school, setSchool] = useState('BinaryCode High School')
+    const [message, setMessage] = useState('Thank you for your donation!')
+    const [supplies, setSupplies] = useState([]);
+
+    const loadSupplies = async () => {
+        // TODO: implement data fetch in AuthService
+
+        // For Testing, delete once back-end is integrated
+        const testData = [
+            {
+                _id: 1,
+                item: 'Pencils',
+                totalQtyNeeded: 10,
+                qtyDonated: 5,
+            },
+            {
+                _id: 2,
+                item: 'Tissue Boxes',
+                totalQtyNeeded: 5,
+                qtyDonated: 1,
+            },
+            {
+                _id: 3,
+                item: 'Scissors',
+                totalQtyNeeded: 15,
+                qtyDonated: 0,
+            },
+        ];
+        setSupplies(testData);
+    };
+
+    useEffect(() => {
+        loadSupplies();
+    }, []);
+
+    return (
+        <>
+            <div className='dashboardHeader'>
+                <Header size='huge' textAlign='center'>
+                    <Header.Content>
+                        Donate Supplies to {teacher}'s Classroom!
+                        <Header.Subheader>{school}</Header.Subheader>
+                    </Header.Content>
+                </Header>
+                <Container textAlign='center'>
+                    <Message size="big" color='olive' compact>{message}</Message>
+                </Container>
+            </div>
+            <Header size="large"> Supplies List</Header>
+            <Divider fitted />
+            <SupplyTableSimple
+                supplies={supplies}
+            />
+            <Container className='buttonRow' textAlign='center'>
+                <Button
+                    type="submit"
+                    as={Link}
+                    to='/'
+                    color='blue'
+
+                    size='huge'
+                    style={{ marginBottom: '1em' }}
+
+                >Add or Update Donation</Button>
+            </Container>
+        </>
+    );
+}
+
+export default TeacherDonationPage;


### PR DESCRIPTION
Teacher donation public page uses a simpler version of table, table row than in the teacher dashboard (no buttons, inputs or editing). Page just has the hardcoded generic data populating

- Added components: TeacherDonationPage, DonationLayout, SupplyTableSimple, SupplyRowSimple
- Opened route: /donations 
- Added a home page return button to sidebar in Teacher Dashboard (since I was already doing it for the Donations Page)

